### PR TITLE
Remove .html extension

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -30,8 +30,8 @@
             Ethnicity facts and figures
           </a>
           <ul class="header-nav">
-            <li><a href="https://www.ethnicity-facts-figures.service.gov.uk/ethnicity-in-the-uk.html">Ethnicity in the UK</a></li>
-            <li><a href="https://www.ethnicity-facts-figures.service.gov.uk/background.html">Background</a></li>
+            <li><a href="https://www.ethnicity-facts-figures.service.gov.uk/ethnicity-in-the-uk">Ethnicity in the UK</a></li>
+            <li><a href="https://www.ethnicity-facts-figures.service.gov.uk/background">Background</a></li>
 
           </ul>
         </nav>


### PR DESCRIPTION
Remove .html extension for links to static site ethnicity and background pages.

@frankieroberto one for you. This is for: https://trello.com/c/dNusYwsO